### PR TITLE
Chuck Norris style fix @Firefox

### DIFF
--- a/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
@@ -1,9 +1,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
     <img src="${rootURL}/plugin/chucknorris/images/icon.jpg" width="16" height="16" alt="${from.displayName} Icon"/><st:nbsp/><j:out value="${from.fact}"/>
     <script>
-        Element.setStyle($('main-table'), {
-            backgroundImage: 'none'
-        });
         Element.setStyle($('main-panel'), {
             backgroundImage: 'url(${rootURL}/plugin/chucknorris/images/<j:out value="${from.style.toString().toLowerCase()}"/>.jpg)',
             backgroundRepeat: 'no-repeat',

--- a/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
@@ -7,5 +7,6 @@
             backgroundPosition: 'bottom right',
             paddingBottom: '270px'
         });
+        document.evaluate("//tr[td[@id='side-panel']]/td[2]/div[2]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue.style.height = "";
     </script>
 </j:jelly>


### PR DESCRIPTION
After activation Chuck and opening job in Firefox - styles pulled out my eyes.
Now styles are correct. Checked on Firefox 21 (don't ask why I use necro version) and Hudson 3.1.2
![before](https://cloud.githubusercontent.com/assets/1556851/3053024/c98c41fe-e1a2-11e3-9a0c-53bb428fdb56.png)
![after](https://cloud.githubusercontent.com/assets/1556851/3053036/ea67c7e0-e1a2-11e3-92b5-87ee1b8ac528.png)

