### PR TITLE
Return Chuck to background image on newer Jenkins.

### DIFF
--- a/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
@@ -1,14 +1,17 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
     <img src="${rootURL}/plugin/chucknorris/images/icon.jpg" width="16" height="16" alt="${from.displayName} Icon"/><st:nbsp/><j:out value="${from.fact}"/>
+    <style>
+        .chuck-style {
+          background-image: url(${rootURL}/plugin/chucknorris/images/<j:out value="${from.style.toString().toLowerCase()}"/>.jpg);
+          background-repeat: no-repeat;
+          background-position: bottom right;
+          padding-bottom: 270px !important;
+        }
+    </style>
     <script>
-        Element.setStyle($('main-table'), {
-            backgroundImage: 'none'
-        });
-        Element.setStyle($('main-panel'), {
-            backgroundImage: 'url(${rootURL}/plugin/chucknorris/images/<j:out value="${from.style.toString().toLowerCase()}"/>.jpg)',
-            backgroundRepeat: 'no-repeat',
-            backgroundPosition: 'bottom right',
-            paddingBottom: '270px'
-        });
+        if($('main-table')) {
+            $('main-table').setStyle({ backgroundImage: 'none' });
+        }
+        $('main-panel').addClassName('chuck-style');
     </script>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/summary.jelly
@@ -3,15 +3,18 @@
         <td><img src="${rootURL}/plugin/chucknorris/images/icon.jpg" width="48" height="48" alt="${it.displayName} Icon"/></td>
         <td style="vertical-align:middle"><j:out value="${it.fact}"/></td>
     </tr>
+    <style>
+        .chuck-style {
+          background-image: url(${rootURL}/plugin/chucknorris/images/<j:out value="${it.style.toString().toLowerCase()}"/>.jpg);
+          background-repeat: no-repeat;
+          background-position: bottom right;
+          padding-bottom: 270px !important;
+        }
+    </style>
     <script>
-        Element.setStyle($('main-table'), {
-            backgroundImage: 'none'
-        });
-        Element.setStyle($('main-panel'), {
-            backgroundImage: 'url(${rootURL}/plugin/chucknorris/images/<j:out value="${it.style.toString().toLowerCase()}"/>.jpg)',
-            backgroundRepeat: 'no-repeat',
-            backgroundPosition: 'bottom right',
-            paddingBottom: '270px'
-        });
+        if($('main-table')) {
+            $('main-table').setStyle({ backgroundImage: 'none' });
+        }
+        $('main-panel').addClassName('chuck-style');
     </script>
 </j:jelly>


### PR DESCRIPTION
This is to fix the issue we saw as well with Chuck not appearing in recent Jenkins.  Referenced in this bug:

https://issues.jenkins-ci.org/browse/JENKINS-25084

'main-table' does not exist in newer Jenkins, but I kept a check in for it for backwards compatibility.  Love this plugin by the way, it's my been my first install after Hudson/Jenkins for many years.