### PR TITLE
[JENKINS-32594] Support jenkins pipeline plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <description>Displays a picture of Chuck Norris (instead of Jenkins the butler) and a random Chuck Norris 'The Programmer' fact on each build page.</description>
 
     <properties>
-        <jenkins.version>1.434</jenkins.version>
+        <jenkins.version>1.577</jenkins.version>
         <hpi-plugin.version>1.115</hpi-plugin.version>
         <jenkins-test-harness.version>${jenkins.version}</jenkins-test-harness.version>
     </properties>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.7</version>
+            <version>1.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
+++ b/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
@@ -27,6 +27,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepMonitor;
@@ -90,10 +91,14 @@ public class CordellWalkerRecorder extends Recorder implements SimpleBuildStep {
     @Override
     public final Action getProjectAction(final AbstractProject<?, ?> project) {
         Action action = null;
-        if (project.getLastBuild() != null) {
-            Style style = Style.get(project.getLastBuild().getResult());
-            String fact = factGenerator.random();
-            action = new RoundhouseAction(style, fact);
+        AbstractBuild<?, ?> build = project.getLastBuild();
+        if (build != null) {
+            Result result = build.getResult();
+            if (result != null) {
+                Style style = Style.get(result);
+                String fact = factGenerator.random();
+                action = new RoundhouseAction(style, fact);
+            }
         }
         return action;
     }

--- a/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
+++ b/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
@@ -21,18 +21,24 @@
  */
 package hudson.plugins.chucknorris;
 
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.BuildListener;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
 
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 /**
  * This class associates a RoundhouseAction to a job or a build. For more info
@@ -41,7 +47,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * >http://www.imdb.com/character/ch0038386/</a>.
  * @author cliffano
  */
-public class CordellWalkerRecorder extends Recorder {
+public class CordellWalkerRecorder extends Recorder implements SimpleBuildStep {
 
     /**
      * Logger.
@@ -111,10 +117,32 @@ public class CordellWalkerRecorder extends Recorder {
     public final boolean perform(final AbstractBuild<?, ?> build,
             final Launcher launcher, final BuildListener listener)
             throws InterruptedException, IOException {
-        Style style = Style.get(build.getResult());
-        String fact = factGenerator.random();
-        build.getActions().add(new RoundhouseAction(style, fact));
+        perform(build);
         return true;
+    }
+
+    /**
+     * Adds RoundhouseAction to the run actions. This is applicable for each
+     * run.
+     * @param run
+     *            the run
+     * @param workspace
+     *            the workspace
+     * @param launcher
+     *            the launcher
+     * @param listener
+     *            the listener
+     * @throws InterruptedException
+     *             when there's an interruption
+     * @throws IOException
+     *             when there's an IO error
+     */
+    @Override
+    public final void perform(
+            @Nonnull final Run<?, ?> run, @Nonnull final FilePath workspace,
+            @Nonnull final Launcher launcher, @Nonnull final TaskListener listener)
+            throws InterruptedException, IOException {
+        perform(run);
     }
 
     /**
@@ -124,4 +152,17 @@ public class CordellWalkerRecorder extends Recorder {
     public final BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
+
+    /**
+     * Adds RoundhouseAction to the run actions. This is applicable for each
+     * run.
+     * @param run
+     *            the run
+     */
+    private void perform(final Run<?, ?> run) {
+        Style style = Style.get(run.getResult());
+        String fact = factGenerator.random();
+        run.addAction(new RoundhouseAction(style, fact));
+    }
+
 }

--- a/src/main/java/hudson/plugins/chucknorris/RoundhouseAction.java
+++ b/src/main/java/hudson/plugins/chucknorris/RoundhouseAction.java
@@ -21,8 +21,13 @@
  */
 package hudson.plugins.chucknorris;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Action;
+import jenkins.tasks.SimpleBuildStep.LastBuildAction;
 
 /**
  * {@link RoundhouseAction} keeps the style and fact associated with the action.
@@ -31,7 +36,7 @@ import hudson.model.Action;
  * >http://www.youtube.com/watch?v=Vb7lnpk3tRY</a>
  * @author cliffano
  */
-public final class RoundhouseAction implements Action {
+public final class RoundhouseAction implements Action, LastBuildAction {
 
     /**
      * The style - for backward compatibility to version 0.2.
@@ -120,4 +125,15 @@ public final class RoundhouseAction implements Action {
         }
         return theFact;
     }
+
+    /**
+     * Returns this action as a collection of all project actions.
+     *
+     * @return the project actions
+     */
+    @Override
+    public Collection<? extends Action> getProjectActions() {
+        return Collections.singletonList(this);
+    }
+
 }

--- a/src/test/java/hudson/plugins/chucknorris/CordellWalkerRecorderTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/CordellWalkerRecorderTest.java
@@ -1,6 +1,10 @@
 package hudson.plugins.chucknorris;
 
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -10,10 +14,8 @@ import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.Result;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import junit.framework.TestCase;
+import org.mockito.ArgumentCaptor;
 
 public class CordellWalkerRecorderTest extends TestCase {
 
@@ -50,24 +52,22 @@ public class CordellWalkerRecorderTest extends TestCase {
 
 	public void testPerformWithFailureResultAddsRoundHouseActionWithBadAssStyleAndExpectedFact()
 			throws Exception {
-		List<Action> actions = new ArrayList<Action>();
 		AbstractBuild mockBuild = mock(AbstractBuild.class);
 		when(mockBuild.getResult()).thenReturn(Result.FAILURE);
-		when(mockBuild.getActions()).thenReturn(actions);
+
+		ArgumentCaptor<RoundhouseAction> actionCaptor = ArgumentCaptor.forClass(RoundhouseAction.class);
+		doNothing().when(mockBuild).addAction(actionCaptor.capture());
 
 		when(mockGenerator.random()).thenReturn(
 				"Chuck Norris burst the dot com bubble.");
 
-		assertEquals(0, actions.size());
-
 		recorder.perform(mockBuild, mock(Launcher.class),
 				mock(BuildListener.class));
 
-		assertEquals(1, actions.size());
-		assertTrue(actions.get(0) instanceof RoundhouseAction);
-		assertEquals(Style.BAD_ASS, ((RoundhouseAction) actions.get(0))
-				.getStyle());
-		assertEquals("Chuck Norris burst the dot com bubble.",
-				((RoundhouseAction) actions.get(0)).getFact());
+		RoundhouseAction action = actionCaptor.getValue();
+
+		verify(mockBuild, times(1)).addAction(same(action));
+		assertEquals(Style.BAD_ASS, (action).getStyle());
+		assertEquals("Chuck Norris burst the dot com bubble.", action.getFact());
 	}
 }


### PR DESCRIPTION
Current version of chucknorris-plugin does not support jenkins pipeline plugin, throwing

```
java.lang.ClassCastException: org.jenkinsci.plugins.workflow.steps.CoreStep.delegate expects interface jenkins.tasks.SimpleBuildStep but received class hudson.plugins.chucknorris.CordellWalkerRecorder
    at org.jenkinsci.plugins.structs.describable.DescribableModel.coerce(DescribableModel.java:317)
    at org.jenkinsci.plugins.structs.describable.DescribableModel.buildArguments(DescribableModel.java:248)
    at org.jenkinsci.plugins.structs.describable.DescribableModel.instantiate(DescribableModel.java:192)
    at org.jenkinsci.plugins.workflow.steps.StepDescriptor.newInstance(StepDescriptor.java:104)
    at org.jenkinsci.plugins.workflow.cps.DSL.invokeMethod(DSL.java:134)
    at org.jenkinsci.plugins.workflow.cps.CpsScript.invokeMethod(CpsScript.java:113)
```

for the following configuration

```
step([
    $class: 'hudson.plugins.chucknorris.CordellWalkerRecorder'
])
```

The provided pullrequest makes CordellWalkerRecorder implement SimpleBuildStep in order to be compatible with jenkins pipeline.
