### PR TITLE
Bump to latest parent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>mockito-core</artifactId>
             <version>1.8.0</version>
             <scope>test</scope>
+            <exclusions>
+              <exclusion> <!-- excluding to take the one from JTH -->
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.33</version>
         <relativePath />
     </parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
@@ -13,9 +13,7 @@
     <description>Displays a picture of Chuck Norris (instead of Jenkins the butler) and a random Chuck Norris 'The Programmer' fact on each build page.</description>
 
     <properties>
-        <jenkins.version>1.577</jenkins.version>
-        <hpi-plugin.version>1.115</hpi-plugin.version>
-        <jenkins-test-harness.version>${jenkins.version}</jenkins-test-harness.version>
+        <jenkins.version>1.651.3</jenkins.version>
     </properties>
 
     <url>http://wiki.jenkins-ci.org/display/JENKINS/ChuckNorris+Plugin</url>
@@ -49,7 +47,7 @@
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public/</url>
-            <releases>  
+            <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
@@ -57,26 +55,6 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <!--
-                    to disable the sisu-guice check
-                    https://github.com/jenkinsci/plugin-pom/blob/2f1d637b5f4384b1c82ff7fc87f66e8c0e991d12/pom.xml#L510
-                    -->
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-            </plugin>
-        </plugins>
-    </build>
 
     <reporting>
         <plugins>
@@ -123,9 +101,9 @@
             </plugin>
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <configuration>  
-                    <targetJdk>1.5</targetJdk>  
-                </configuration> 
+                <configuration>
+                    <targetJdk>1.5</targetJdk>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
@@ -135,7 +113,7 @@
             </plugin>
         </plugins>
     </reporting>
-    
+
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/chucknorris-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/chucknorris-plugin.git</developerConnection>
@@ -149,5 +127,4 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
-
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <plugin>
                 <artifactId>maven-pmd-plugin</artifactId>
                 <configuration>
-                    <targetJdk>1.5</targetJdk>
+                    <targetJdk>1.${java.level}</targetJdk>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Bumped into the old maven repo (on port 8081) while trying to release a beta from https://github.com/jenkinsci/chucknorris-plugin/pull/9#issuecomment-329468487

So bumping the parent pom and using the PR build to check I'm not missing something.

@reviewbybees esp. @jtnord :-)