### PR TITLE
Fix for pipeline projects and JENKINS-32594

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jenkins.version>1.651.3</jenkins.version>
+		<workflow.version>1.14</workflow.version>
     </properties>
 
     <url>http://wiki.jenkins-ci.org/display/JENKINS/ChuckNorris+Plugin</url>
@@ -35,6 +36,11 @@
     </licenses>
 
     <dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-step-api</artifactId>
+			<version>${workflow.version}</version>
+		</dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -47,6 +53,19 @@
               </exclusion>
             </exclusions>
         </dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-aggregator</artifactId>
+			<version>${workflow.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins.workflow</groupId>
+			<artifactId>workflow-support</artifactId>
+			<version>${workflow.version}</version>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
+++ b/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
@@ -78,7 +78,7 @@ public class CordellWalkerRecorder extends Recorder implements SimpleBuildStep {
      */
     public CordellWalkerRecorder(final FactGenerator factGenerator) {
         this.factGenerator = factGenerator;
-        LOGGER.info("Chuck Norris is activated");
+        LOGGER.fine("Chuck Norris is activated");
     }
 
     /**

--- a/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
+++ b/src/main/java/hudson/plugins/chucknorris/CordellWalkerRecorder.java
@@ -164,7 +164,7 @@ public class CordellWalkerRecorder extends Recorder implements SimpleBuildStep {
      * @param run
      *            the run
      */
-    private void perform(final Run<?, ?> run) {
+    public void perform(final Run<?, ?> run) {
         Style style = Style.get(run.getResult());
         String fact = factGenerator.random();
         run.addAction(new RoundhouseAction(style, fact));

--- a/src/main/java/hudson/plugins/chucknorris/FactGenerator.java
+++ b/src/main/java/hudson/plugins/chucknorris/FactGenerator.java
@@ -111,7 +111,11 @@ public class FactGenerator {
             "Chuck Norris has root access to your system.",
             "When Chuck Norris gives a method an argument, the method loses",
             "Chuck Norris' keyboard doesn't have F1 key, the computer asks for help from him.",
-            "When Chuck Norris presses Ctrl+Alt+Delete, worldwide computers restart is initiated."};
+            "When Chuck Norris presses Ctrl+Alt+Delete, worldwide computers restart is initiated.",
+            "When Chuck Norris throws exceptions, it’s across the room.",
+            "Chuck Norris doesn’t do Burn Down charts, he does Smack Down charts.",
+            "Chuck Norris can delete the Recycling Bin.",
+            "When Chuck Norris is web surfing websites get the message \"Warning: Internet Explorer has deemed this user to be malicious or dangerous. Proceed?\"."};
 
     /**
      * Random instance.

--- a/src/main/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStep.java
+++ b/src/main/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStep.java
@@ -1,0 +1,34 @@
+package hudson.plugins.chucknorris.pipeline;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+
+public class ChuckNorrisStep extends AbstractStepImpl {
+
+	@DataBoundConstructor
+	public ChuckNorrisStep() {
+	}
+
+	@Extension
+	public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+		public DescriptorImpl() {
+			super(ChuckNorrisStepExecution.class);
+		}
+
+		@Override
+		public String getFunctionName() {
+			return "chuckNorris";
+		}
+
+		@Nonnull
+		@Override
+		public String getDisplayName() {
+			return "Submit to Chuck Norris' will";
+		}
+	}
+}

--- a/src/main/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepExecution.java
+++ b/src/main/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepExecution.java
@@ -1,0 +1,31 @@
+package hudson.plugins.chucknorris.pipeline;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.plugins.chucknorris.CordellWalkerRecorder;
+
+public class ChuckNorrisStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+
+	/** serialVersionUID. */
+	private static final long serialVersionUID = 1L;
+
+	@StepContextParameter
+	private transient TaskListener listener;
+
+    @StepContextParameter
+    private transient Run<?, ?> run;
+
+	@Override
+	protected Void run() throws Exception {
+		listener.getLogger().println("Submitting to Chuck's will");
+		
+		CordellWalkerRecorder recorder = new CordellWalkerRecorder();
+		recorder.perform(run);
+		
+		return null;
+	}
+
+}

--- a/src/main/resources/hudson/plugins/chucknorris/pipeline/ChuckNorrisStep/config.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/pipeline/ChuckNorrisStep/config.jelly
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+</j:jelly>

--- a/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
@@ -1,14 +1,47 @@
 package hudson.plugins.chucknorris;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
 import junit.framework.TestCase;
 
 public class RoundhouseActionTest extends TestCase {
 
 	private RoundhouseAction action;
 
+	private Run<?, ?> run;
+	private RoundhouseAction lastBuildAction;
+
+	@SuppressWarnings("rawtypes")
 	public void setUp() {
 		action = new RoundhouseAction(Style.BAD_ASS,
 				"Chuck Norris can divide by zero.");
+
+		run = mock(Run.class);
+		given(run.getResult()).willReturn(Result.SUCCESS);
+
+		lastBuildAction = new RoundhouseAction(Style.ALERT,
+				"Chuck Norris went out of an infinite loop.");
+		final Job job = mock(Job.class);
+		Run<?, ?> lastRun = mock(Run.class);
+
+		given(run.getParent()).willAnswer(new Answer<Job>() {
+			@Override
+			public Job answer(InvocationOnMock invocation) throws Throwable {
+				return job;
+			}
+		});
+		given(job.getLastCompletedBuild()).willReturn(lastRun);
+		given(lastRun.getActions(eq(RoundhouseAction.class))).willReturn(Arrays.asList(lastBuildAction));
 	}
 
 	public void testAccessors() {
@@ -18,5 +51,25 @@ public class RoundhouseActionTest extends TestCase {
 		assertEquals("Chuck Norris", action.getDisplayName());
 		assertNull(action.getIconFileName());
 		assertEquals("chucknorris", action.getUrlName());
+	}
+
+	public void testGetProjectActions() {
+		assertNotNull(action.getProjectActions());
+		assertEquals(1, action.getProjectActions().size());
+		assertSame(action, action.getProjectActions().iterator().next());
+	}
+
+	public void testGetStyleFromRunResult() {
+		action.onAttached(run);
+
+		assertEquals(Style.THUMB_UP, action.getStyle());
+	}
+
+	public void testGetProjectActionsFromLastProjectBuild() {
+		action.onAttached(run);
+
+		assertNotNull(action.getProjectActions());
+		assertEquals(1, action.getProjectActions().size());
+		assertSame(lastBuildAction, action.getProjectActions().iterator().next());
 	}
 }

--- a/src/test/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepTest.java
@@ -1,0 +1,136 @@
+package hudson.plugins.chucknorris.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import hudson.model.Result;
+import hudson.plugins.chucknorris.RoundhouseAction;
+import hudson.plugins.chucknorris.Style;
+
+public class ChuckNorrisStepTest {
+	@Rule
+	public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @Test
+    public void badAssChuckNorris() throws Exception {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"chuckNorris()\n" +
+						"semaphore 'wait'\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait/1", b1);
+				SemaphoreStep.failure("wait/1", new Exception());
+				
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.FAILURE, b1);
+				
+				RoundhouseAction action = b1.getAction(RoundhouseAction.class);
+				assertEquals(Style.BAD_ASS, action.getStyle());
+				assertNotNull(action.getFact());
+			}
+		});
+    }
+
+    @Test
+    public void alertChuckNorris() throws Exception {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"chuckNorris()\n" +
+						"semaphore 'wait'\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait/1", b1);
+				b1.setResult(Result.UNSTABLE);
+				SemaphoreStep.success("wait/1", null);
+				
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.UNSTABLE, b1);
+				
+				RoundhouseAction action = b1.getAction(RoundhouseAction.class);
+				assertEquals(Style.ALERT, action.getStyle());
+				assertNotNull(action.getFact());
+			}
+		});
+    }
+
+    @Test
+    public void thumbsUpChuckNorris() throws Exception {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"chuckNorris()\n" +
+						"semaphore 'wait'\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait/1", b1);
+				SemaphoreStep.success("wait/1", null);
+				
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				
+				RoundhouseAction action = b1.getAction(RoundhouseAction.class);
+				assertEquals(Style.THUMB_UP, action.getStyle());
+				assertNotNull(action.getFact());
+			}
+		});
+    }
+
+    @Test
+    public void projectPageChuckNorris() throws Exception {
+		story.addStep(new Statement() {
+			@Override
+			public void evaluate() throws Throwable {
+				WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+				p.setDefinition(new CpsFlowDefinition(
+						"chuckNorris()\n" +
+						"semaphore 'wait'\n"
+				));
+				WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait/1", b1);
+				
+				WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+				SemaphoreStep.waitForStart("wait/2", b2);
+				
+				SemaphoreStep.success("wait/1", null);
+				SemaphoreStep.failure("wait/2", new Exception());
+				
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.SUCCESS, b1);
+				
+				story.j.waitForCompletion(b1);
+				story.j.assertBuildStatus(Result.FAILURE, b2);
+				
+				RoundhouseAction action1 = b1.getAction(RoundhouseAction.class);
+				assertEquals(Style.THUMB_UP, action1.getStyle());
+				assertNotNull(action1.getFact());
+				
+				RoundhouseAction action2 = b2.getAction(RoundhouseAction.class);
+				assertEquals(Style.BAD_ASS, action2.getStyle());
+				assertNotNull(action2.getFact());
+				
+				// Make sure we get the action from the last completed build (jenkins default behaviour is last successful build)
+				RoundhouseAction projectAction = p.getAction(RoundhouseAction.class);
+				assertEquals(Style.BAD_ASS, projectAction.getStyle());
+				assertNotNull(projectAction.getFact());
+			}
+		});
+    }
+}


### PR DESCRIPTION
I noticed the Chuck Norris image is often wrong on pipeline projects. This is because the Style is set when the action is created and the build status might be changed afterwards by another plugin.
e.g.: JUnit might change the build to unstable.

Even when running chuck norris completely at the end, the status is often wrong (even null most of the time), so I modified the action to get a reference to the run and query the build status instead. I kept the "old" behavior as well just in case although the change seems to be applied to existing actions once the new plugin is installed (they will be "injected" a copy of the run when Jenkins re-creates the action)

Last modification, the project was showing the action of the last successful build (Stable or Unstable) while we want the last complected build (Stable, Unstable or Failed) like we had pre 1.1

Following the comments on JENKINS-32594 that it was not obvious how to use the plugin in pipeline projects, I've added better support and the plugin now has its own entry in the snippet generator.
