### PR TITLE
:bug: Stop chuck norris image from displaying behind other charts/ele…

### DIFF
--- a/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
+++ b/src/main/resources/hudson/plugins/chucknorris/RoundhouseAction/floatingBox.jelly
@@ -1,6 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:local="local">
-    <img src="${rootURL}/plugin/chucknorris/images/icon.jpg" width="16" height="16" alt="${from.displayName} Icon"/><st:nbsp/><j:out value="${from.fact}"/>
+    <div align="right" style="position:relative; z-index:1;" class="chuck-style">
+        <img src="${rootURL}/plugin/chucknorris/images/icon.jpg" width="16" height="16" alt="${from.displayName} Icon"/><st:nbsp/><j:out value="${from.fact}"/>
+    </div>
     <style>
         .chuck-style {
           background-image: url(${rootURL}/plugin/chucknorris/images/<j:out value="${from.style.toString().toLowerCase()}"/>.jpg);
@@ -9,10 +11,4 @@
           padding-bottom: 270px !important;
         }
     </style>
-    <script>
-        if($('main-table')) {
-            $('main-table').setStyle({ backgroundImage: 'none' });
-        }
-        $('main-panel').addClassName('chuck-style');
-    </script>
 </j:jelly>


### PR DESCRIPTION
…ments that might be on the page

The Chuck Norris image sometimes is hidden by other graphs and plugins that might be installed, this code cleans up the html containing it in its own Div which can move relative to the other divs, rather than setting the background of the page which gets covered