### PR TITLE
Migrate tests from JUnit 4 to JUnit Jupiter

### DIFF
--- a/src/test/java/hudson/plugins/chucknorris/BeardDescriptorTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/BeardDescriptorTest.java
@@ -1,24 +1,28 @@
 package hudson.plugins.chucknorris;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import hudson.model.AbstractProject;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class BeardDescriptorTest extends TestCase {
+class BeardDescriptorTest {
 
     private BeardDescriptor descriptor;
 
-    @Override
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         descriptor = new BeardDescriptor();
     }
 
-    public void testGetDisplayName() {
+    @Test
+    void testGetDisplayName() {
         assertEquals("Activate Chuck Norris", descriptor.getDisplayName());
     }
 
-    public void testIsApplicableGivesTrue() {
+    @Test
+    void testIsApplicableGivesTrue() {
         assertTrue(descriptor.isApplicable(mock(AbstractProject.class).getClass()));
     }
 }

--- a/src/test/java/hudson/plugins/chucknorris/CordellWalkerRecorderTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/CordellWalkerRecorderTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.chucknorris;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
@@ -14,27 +15,30 @@ import hudson.model.Action;
 import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.Result;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-public class CordellWalkerRecorderTest extends TestCase {
+class CordellWalkerRecorderTest {
 
     private FactGenerator mockGenerator;
     private CordellWalkerRecorder recorder;
 
-    @Override
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         mockGenerator = mock(FactGenerator.class);
         recorder = new CordellWalkerRecorder(mockGenerator);
     }
 
-    public void testGetProjectActionWithNoLastBuildGivesNullAction() {
+    @Test
+    void testGetProjectActionWithNoLastBuildGivesNullAction() {
         AbstractProject mockProject = mock(AbstractProject.class);
         when(mockProject.getLastBuild()).thenReturn(null);
         assertNull(recorder.getProjectAction(mockProject));
     }
 
-    public void testGetProjectActionHavingLastBuildGivesRoundhouseAction() {
+    @Test
+    void testGetProjectActionHavingLastBuildGivesRoundhouseAction() {
         AbstractProject mockProject = mock(AbstractProject.class);
         Build mockBuild = mock(Build.class);
 
@@ -44,12 +48,13 @@ public class CordellWalkerRecorderTest extends TestCase {
 
         Action action = recorder.getProjectAction(mockProject);
 
-        assertTrue(action instanceof RoundhouseAction);
+        assertInstanceOf(RoundhouseAction.class, action);
         assertEquals(Style.THUMB_UP, ((RoundhouseAction) action).getStyle());
         assertNotNull(((RoundhouseAction) action).getFact());
     }
 
-    public void testPerformWithFailureResultAddsRoundHouseActionWithBadAssStyleAndExpectedFact() throws Exception {
+    @Test
+    void testPerformWithFailureResultAddsRoundHouseActionWithBadAssStyleAndExpectedFact() throws Exception {
         AbstractBuild mockBuild = mock(AbstractBuild.class);
         when(mockBuild.getResult()).thenReturn(Result.FAILURE);
 

--- a/src/test/java/hudson/plugins/chucknorris/FactGeneratorTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/FactGeneratorTest.java
@@ -1,17 +1,21 @@
 package hudson.plugins.chucknorris;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class FactGeneratorTest extends TestCase {
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FactGeneratorTest {
 
     private FactGenerator generator;
 
-    @Override
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         generator = new FactGenerator();
     }
 
-    public void testRandomGivesAtLeast2Facts() {
+    @Test
+    void testRandomGivesAtLeast2Facts() {
         String lastFact = null;
         for (int i = 0; i < 1000000; i++) {
             String currFact = generator.random();

--- a/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
@@ -1,5 +1,6 @@
 package hudson.plugins.chucknorris;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -7,20 +8,21 @@ import static org.mockito.Mockito.mock;
 import hudson.model.Job;
 import hudson.model.Run;
 import java.util.Arrays;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-public class RoundhouseActionTest extends TestCase {
+class RoundhouseActionTest {
 
     private RoundhouseAction action;
 
     private Run<?, ?> run;
     private RoundhouseAction lastBuildAction;
 
-    @Override
+    @BeforeEach
     @SuppressWarnings("rawtypes")
-    public void setUp() {
+    void setUp() {
         action = new RoundhouseAction(Style.BAD_ASS, "Chuck Norris can divide by zero.");
 
         run = mock(Run.class);
@@ -39,7 +41,8 @@ public class RoundhouseActionTest extends TestCase {
         given(lastRun.getActions(eq(RoundhouseAction.class))).willReturn(Arrays.asList(lastBuildAction));
     }
 
-    public void testGetProjectActionsFromLastProjectBuild() {
+    @Test
+    void testGetProjectActionsFromLastProjectBuild() {
         action.onAttached(run);
 
         assertNotNull(action.getProjectActions());

--- a/src/test/java/hudson/plugins/chucknorris/SecondRoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/SecondRoundhouseActionTest.java
@@ -1,24 +1,21 @@
 package hudson.plugins.chucknorris;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class SecondRoundhouseActionTest {
+class SecondRoundhouseActionTest {
 
     private RoundhouseAction action;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         action = new RoundhouseAction(Style.BAD_ASS, "Chuck Norris can divide by zero.");
     }
 
     @Test
-    public void testAccessors() {
+    void testAccessors() {
         assertEquals(Style.BAD_ASS, action.getStyle());
         assertEquals("Chuck Norris can divide by zero.", action.getFact());
         assertEquals("Chuck Norris", action.getDisplayName());
@@ -27,7 +24,7 @@ public class SecondRoundhouseActionTest {
     }
 
     @Test
-    public void testGetProjectActions() {
+    void testGetProjectActions() {
         assertNotNull(action.getProjectActions());
         assertEquals(1, action.getProjectActions().size());
         assertSame(action, action.getProjectActions().iterator().next());

--- a/src/test/java/hudson/plugins/chucknorris/StyleTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/StyleTest.java
@@ -1,27 +1,34 @@
 package hudson.plugins.chucknorris;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import hudson.model.Result;
-import junit.framework.TestCase;
+import org.junit.jupiter.api.Test;
 
-public class StyleTest extends TestCase {
+class StyleTest {
 
-    public void testGetWithFailureResultGivesBadAssStyle() {
+    @Test
+    void testGetWithFailureResultGivesBadAssStyle() {
         assertEquals(Style.BAD_ASS, Style.get(Result.FAILURE));
     }
 
-    public void testGetWithSuccessResultGivesSuitupStyle() {
+    @Test
+    void testGetWithSuccessResultGivesSuitupStyle() {
         assertEquals(Style.THUMB_UP, Style.get(Result.SUCCESS));
     }
 
-    public void testGetWithAbortedResultGivesAlertStyle() {
+    @Test
+    void testGetWithAbortedResultGivesAlertStyle() {
         assertEquals(Style.ALERT, Style.get(Result.ABORTED));
     }
 
-    public void testGetWithNotBuiltResultGivesAlertStyle() {
+    @Test
+    void testGetWithNotBuiltResultGivesAlertStyle() {
         assertEquals(Style.ALERT, Style.get(Result.NOT_BUILT));
     }
 
-    public void testGetWithUnstableResultGivesAlertStyle() {
+    @Test
+    void testGetWithUnstableResultGivesAlertStyle() {
         assertEquals(Style.ALERT, Style.get(Result.UNSTABLE));
     }
 }

--- a/src/test/java/hudson/plugins/chucknorris/ThirdRoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/ThirdRoundhouseActionTest.java
@@ -1,23 +1,23 @@
 package hudson.plugins.chucknorris;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import hudson.model.Result;
 import hudson.model.Run;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class ThirdRoundhouseActionTest {
+class ThirdRoundhouseActionTest {
 
     private RoundhouseAction action;
 
     private Run<?, ?> run;
 
-    @Before
+    @BeforeEach
     @SuppressWarnings("rawtypes")
-    public void setUp() {
+    void setUp() {
         action = new RoundhouseAction(Style.BAD_ASS, "Chuck Norris can divide by zero.");
 
         run = mock(Run.class);
@@ -25,7 +25,7 @@ public class ThirdRoundhouseActionTest {
     }
 
     @Test
-    public void testGetStyleFromRunResult() {
+    void testGetStyleFromRunResult() {
         action.onAttached(run);
 
         assertEquals(Style.THUMB_UP, action.getStyle());

--- a/src/test/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/pipeline/ChuckNorrisStepTest.java
@@ -1,8 +1,6 @@
 package hudson.plugins.chucknorris.pipeline;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import hudson.model.Result;
@@ -17,28 +15,35 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ChuckNorrisStepTest {
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ChuckNorrisStepTest {
+
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
 
     @Test
-    public void descriptorFunctionName() {
+    void descriptorFunctionName() {
         ChuckNorrisStep.DescriptorImpl descriptor = new ChuckNorrisStep.DescriptorImpl();
         assertEquals("chuckNorris", descriptor.getFunctionName());
     }
 
     @Test
-    public void descriptorDisplayName() {
+    void descriptorDisplayName() {
         ChuckNorrisStep.DescriptorImpl descriptor = new ChuckNorrisStep.DescriptorImpl();
         assertEquals("Submit to Chuck Norris' will", descriptor.getDisplayName());
     }
 
     @Test
-    public void descriptorRequiredContext() {
+    void descriptorRequiredContext() {
         ChuckNorrisStep.DescriptorImpl descriptor = new ChuckNorrisStep.DescriptorImpl();
         Set<? extends Class<?>> required = descriptor.getRequiredContext();
         assertTrue(required.contains(Run.class));
@@ -47,16 +52,16 @@ public class ChuckNorrisStepTest {
     }
 
     @Test
-    public void stepStartReturnsExecution() throws Exception {
+    void stepStartReturnsExecution() throws Exception {
         ChuckNorrisStep step = new ChuckNorrisStep();
         StepContext mockContext = mock(StepContext.class);
         StepExecution execution = step.start(mockContext);
         assertNotNull(execution);
-        assertTrue(execution instanceof ChuckNorrisStepExecution);
+        assertInstanceOf(ChuckNorrisStepExecution.class, execution);
     }
 
     @Test
-    public void badAssChuckNorris() throws Exception {
+    void badAssChuckNorris() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("chuckNorris()\n" + "semaphore 'wait'\n", true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -72,7 +77,7 @@ public class ChuckNorrisStepTest {
     }
 
     @Test
-    public void alertChuckNorris() throws Exception {
+    void alertChuckNorris() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("chuckNorris()\n" + "semaphore 'wait'\n", true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -89,7 +94,7 @@ public class ChuckNorrisStepTest {
     }
 
     @Test
-    public void thumbsUpChuckNorris() throws Exception {
+    void thumbsUpChuckNorris() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("chuckNorris()\n" + "semaphore 'wait'\n", true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
@@ -105,7 +110,7 @@ public class ChuckNorrisStepTest {
     }
 
     @Test
-    public void projectPageChuckNorris() throws Exception {
+    void projectPageChuckNorris() throws Exception {
         WorkflowJob p = j.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("chuckNorris()\n" + "semaphore 'wait'\n", true));
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();


### PR DESCRIPTION
Replace JUnit 3 TestCase and JUnit 4 annotations with JUnit Jupiter equivalents across all 8 test files, eliminating the JUnit Vintage engine deprecation warnings during builds.

- Convert TestCase subclasses to standalone classes with @Test and @BeforeEach
- Replace @Rule JenkinsRule with @WithJenkins and @BeforeEach injection
- Update assertions from junit.framework/org.junit to org.junit.jupiter.api
- Use assertInstanceOf where assertTrue(instanceof) was used

### Testing done

- `mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
