### PR TITLE
Fix NPE in getProjectActions() when no builds have completed

### DIFF
--- a/src/main/java/hudson/plugins/chucknorris/RoundhouseAction.java
+++ b/src/main/java/hudson/plugins/chucknorris/RoundhouseAction.java
@@ -148,10 +148,12 @@ public final class RoundhouseAction implements RunAction2, LastBuildAction {
     @Override
     public Collection<? extends Action> getProjectActions() {
         if (mRun != null) {
-            return mRun.getParent().getLastCompletedBuild().getActions(RoundhouseAction.class);
-        } else {
-            return Collections.singletonList(this);
+            Run<?, ?> lastBuild = mRun.getParent().getLastCompletedBuild();
+            if (lastBuild != null) {
+                return lastBuild.getActions(RoundhouseAction.class);
+            }
         }
+        return Collections.singletonList(this);
     }
 
     @Override

--- a/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/RoundhouseActionTest.java
@@ -49,4 +49,27 @@ class RoundhouseActionTest {
         assertEquals(1, action.getProjectActions().size());
         assertSame(lastBuildAction, action.getProjectActions().iterator().next());
     }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void testGetProjectActionsWhenNoCompletedBuild() {
+        RoundhouseAction actionWithNoCompletedBuild = new RoundhouseAction(Style.BAD_ASS, "fact");
+        Run<?, ?> runWithNoCompletedBuild = mock(Run.class);
+        final Job jobWithNoCompletedBuild = mock(Job.class);
+        given(runWithNoCompletedBuild.getParent()).willAnswer(new Answer<Job>() {
+            @Override
+            public Job answer(InvocationOnMock invocation) throws Throwable {
+                return jobWithNoCompletedBuild;
+            }
+        });
+        given(jobWithNoCompletedBuild.getLastCompletedBuild()).willReturn(null);
+
+        actionWithNoCompletedBuild.onAttached(runWithNoCompletedBuild);
+
+        assertNotNull(actionWithNoCompletedBuild.getProjectActions());
+        assertEquals(1, actionWithNoCompletedBuild.getProjectActions().size());
+        assertSame(
+                actionWithNoCompletedBuild,
+                actionWithNoCompletedBuild.getProjectActions().iterator().next());
+    }
 }


### PR DESCRIPTION
getLastCompletedBuild() returns null when the first build is still running, causing a NullPointerException on the project page. Add a null check to fall back to the current action instead.

<!-- Please describe your pull request here. -->

### Testing done

- `mvn clean verify`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
