### PR TITLE
Update Claude Code configuration and project documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true,
+    "jdtls-lsp@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/add-translation/SKILL.md
+++ b/.claude/skills/add-translation/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: add-translation
+description: "Add a new language translation to a Java project using ResourceBundle-based i18n. Translates all entries, verifies quality via independent Google Translate back-translation, adds tests, updates docs, and handles git workflow. Use this skill whenever the user asks to add a translation, translate to a new language, add a locale, or do i18n work on a Java project with .properties files."
+---
+
+# Add Translation
+
+Adds a complete new language translation to a Java project that uses `ResourceBundle`-based i18n. The key quality gate is independent back-translation verification via Google Translate — this catches issues that same-model translation/verification misses (ambiguous words, broken puns, wrong technical terms).
+
+## Input Validation
+
+Before doing any work, validate the user's request:
+
+1. **No language specified** — ask the user which language they want to add. Do not guess.
+
+2. **Validate the language/locale code:**
+   - The user may provide a language name ("Slovak", "French") or a locale code ("sk", "fr", "pt_BR", "en_GB")
+   - Map language names to ISO 639-1 codes. If a specific regional code is given (e.g., `en_US`, `pt_BR`), validate that both the language and country parts are real ISO codes
+   - If the language is not a real language or the code is not a valid ISO 639-1 (or 639-1 + ISO 3166-1 for regional variants), tell the user the language/code is invalid and stop. Do not attempt to translate to fictional or made-up languages
+
+3. **Check for existing translations** — search the project for a properties file with this locale suffix (e.g., `_sk`, `_pt_BR`). If one already exists, tell the user the translation already exists and point them to the file path. Do not overwrite it unless they explicitly ask
+
+## Phase 1: Discovery
+
+1. **Find ResourceBundle files** — search for `*.properties` files under `src/` that follow the pattern `BaseName.properties` / `BaseName_xx.properties`. The base file (no locale suffix) is the English source.
+
+2. **If multiple ResourceBundle families exist**, list them and ask the user which one to translate.
+
+3. **Parse the base file** to determine:
+   - Total number of translatable entries (skip metadata keys whose values are just numbers, like `fact.count=82`)
+   - Key naming pattern (e.g., `fact.0` through `fact.81`)
+   - Any special escaping conventions (`\=`, `\:`)
+
+4. **Locate supporting files:**
+   - Test class: search `src/test/` for `*Test.java` files that reference the ResourceBundle class name
+   - README or docs: check for `README.md` in project root
+   - Build config: read `CLAUDE.md` if it exists for project-specific build commands
+
+5. **Report findings** to the user before proceeding.
+
+**If no .properties files are found**, inform the user this project doesn't use ResourceBundle i18n and stop.
+
+## Phase 2: Translation
+
+1. Create `BaseName_XX.properties` (or `BaseName_xx_YY.properties` for regional variants) in the same directory as the base file.
+
+2. Add a comment header matching existing translations (e.g., `# Topic facts (Language Name)`).
+
+3. Copy all key-value pairs. For each value:
+   - Translate to the target language
+   - Use `\uXXXX` Unicode escapes for ALL non-ASCII characters — this is required by Java .properties format
+   - Preserve `\=` and `\:` escaping for literal equals/colons in values
+   - Preserve format placeholders (`{0}`, `%s`, `%d`, etc.) exactly as-is
+   - Preserve code identifiers, class names, method names (e.g., `.Dispose()`, `.DropKick()`, `ChuckNorrisException`)
+   - Preserve proper nouns and technical terms (e.g., `NP-Hard`, `RSA`, `GOTO`)
+   - Maintain humor, puns, and wordplay. When a pun is language-specific (e.g., "expressions" meaning both facial expressions and regular expressions), find the closest equivalent in the target language that preserves the double meaning
+
+4. Include any metadata keys unchanged (e.g., `fact.count=82`).
+
+## Phase 3: Back-Translation Verification
+
+This is the critical quality gate. Claude's own back-translation has blind spots because the same model translating in both directions can make consistent errors that cancel out. Google Translate provides an independent signal.
+
+### First pass: Full verification
+
+Run the bundled script to back-translate all entries via Google Translate:
+
+```bash
+python3 ~/.claude/skills/add-translation/scripts/back_translate.py \
+  <translated_file> <locale_code> <base_english_file>
+```
+
+The script outputs JSON with each entry's `original_english`, `translated` text, and `back_translated` text from Google Translate.
+
+Review every entry in the output. For each one, compare the Google Translate back-translation to the original English and flag issues:
+- **Semantic errors**: meaning changed, puns broken, wrong technical terms, ambiguous words that Google resolved differently than intended
+- **Typos**: words in the translation that produced garbled back-translations
+- **Tone/nuance**: intensifiers lost, metaphors changed, tense shifts, missing qualifiers
+
+Fix all flagged issues in the properties file.
+
+### Second pass: Re-verify fixes
+
+Re-run the script with only the fixed keys to confirm the fixes landed:
+
+```bash
+python3 ~/.claude/skills/add-translation/scripts/back_translate.py \
+  <translated_file> <locale_code> <base_english_file> key1 key2 key3
+```
+
+If issues persist after this second fix iteration, present the remaining problems to the user with:
+- The original English text
+- The current translation
+- The Google Translate back-translation
+- The nature of the discrepancy
+
+Ask the user whether each remaining issue is acceptable or needs manual intervention. Some differences are inherent to translation (e.g., Google Translate rendering "beard" as "chin" in languages where one word covers both) and are fine to accept.
+
+## Phase 4: Test & Documentation
+
+1. **Add a test** in the existing test class, following the pattern of other locale tests:
+   - Method name: `testGetFactReturns<Language>` (e.g., `testGetFactReturnsSlovak`)
+   - Get entry 0 in English, get entry 0 in the new locale, assert they are not equal
+   - Use `Locale.<CONSTANT>` if Java provides one (e.g., `Locale.FRENCH`), otherwise `new Locale("xx")` or `Locale.of("xx", "YY")` for regional variants
+   - Use JUnit 5 (Jupiter) — JUnit 4 imports are banned in most Jenkins projects
+
+2. **Update README.md** — add the new language to the localization/supported languages section, maintaining alphabetical order.
+
+3. **Run the build** to verify everything passes. Use the command from CLAUDE.md if available, otherwise `mvn clean verify`. If formatting fails, run the project's formatter (e.g., `mvn spotless:apply`) and retry.
+
+**If no test file is found**, skip the test but warn the user. Same for README.
+
+## Phase 5: Git Workflow
+
+1. **Create a branch** named `feature/i18n-<bundle-basename-lowercase>-XX` (e.g., `feature/i18n-facts-sk` for Slovak facts).
+
+2. **Stage** the new properties file, modified test file, and modified README.
+
+3. **Commit** with a title and descriptive body:
+   - Title: `Add <Language> translation of <description>`
+   - Body: describe what was translated, that quality was verified via Google Translate back-translation, and list the files changed
+
+4. **Push** to remote with `git push -u origin <branch>`.
+
+5. Do **not** create a PR — just report the branch name to the user.

--- a/.claude/skills/add-translation/scripts/back_translate.py
+++ b/.claude/skills/add-translation/scripts/back_translate.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Back-translate a Java .properties file via Google Translate and output comparison data.
+
+Outputs JSON with each entry's original English, translated text, and Google Translate
+back-translation. Does NOT judge quality - that's Claude's job. This script just
+provides independent back-translation data for review.
+"""
+
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+
+def parse_properties(filepath):
+    """Parse a Java .properties file, decoding \\uXXXX escapes. Returns ordered list of (key, value)."""
+    entries = []
+    with open(filepath, "r") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line or line.startswith("#") or line.startswith("!"):
+                continue
+            m = re.match(r"^([^=\\]*(?:\\.[^=\\]*)*)=(.*)", line)
+            if not m:
+                continue
+            key = m.group(1).strip()
+            value = m.group(2)
+            entries.append((key, value))
+    return entries
+
+
+def decode_unicode_escapes(text):
+    """Decode Java \\uXXXX escapes and backslash-escaped special chars to readable text."""
+    decoded = re.sub(
+        r"\\u([0-9a-fA-F]{4})", lambda m: chr(int(m.group(1), 16)), text
+    )
+    decoded = decoded.replace("\\=", "=")
+    decoded = decoded.replace("\\:", ":")
+    return decoded
+
+
+def google_translate(text, src_lang, tgt_lang="en", retries=1):
+    """Translate text via Google Translate API. Returns translated string or None on failure."""
+    url = "https://translate.googleapis.com/translate_a/single"
+    params = urllib.parse.urlencode(
+        {"client": "gtx", "sl": src_lang, "tl": tgt_lang, "dt": "t", "q": text}
+    )
+    req = urllib.request.Request(f"{url}?{params}")
+    req.add_header("User-Agent", "Mozilla/5.0")
+
+    for attempt in range(retries + 1):
+        try:
+            resp = urllib.request.urlopen(req, timeout=10)
+            data = json.loads(resp.read().decode("utf-8"))
+            return "".join(part[0] for part in data[0] if part[0])
+        except Exception as e:
+            if attempt < retries:
+                print(f"  Retry after error: {e}", file=sys.stderr)
+                time.sleep(2)
+            else:
+                return None
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "Usage: back_translate.py <translated_file> <source_locale> <base_english_file> [key1 key2 ...]",
+            file=sys.stderr,
+        )
+        print(
+            "  If keys are provided, only those entries are back-translated.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    translated_file = sys.argv[1]
+    source_locale = sys.argv[2]
+    base_file = sys.argv[3]
+    filter_keys = set(sys.argv[4:]) if len(sys.argv) > 4 else None
+
+    translated_entries = parse_properties(translated_file)
+    base_entries = parse_properties(base_file)
+
+    base_dict = {k: v for k, v in base_entries}
+    translated_dict = {k: v for k, v in translated_entries}
+
+    # Skip metadata keys (values that are just numbers)
+    skip_keys = {k for k, v in base_entries if v.strip().isdigit()}
+
+    keys_to_check = [
+        k
+        for k, _ in base_entries
+        if k in translated_dict and k not in skip_keys
+    ]
+
+    if filter_keys:
+        keys_to_check = [k for k in keys_to_check if k in filter_keys]
+
+    total = len(keys_to_check)
+    results = []
+
+    print(
+        f"Back-translating {total} entries from '{source_locale}' to 'en'...",
+        file=sys.stderr,
+    )
+
+    for i, key in enumerate(keys_to_check):
+        original_en = decode_unicode_escapes(base_dict[key])
+        translated_text = decode_unicode_escapes(translated_dict[key])
+
+        print(f"  [{i + 1}/{total}] {key}", file=sys.stderr)
+
+        back_translated = google_translate(translated_text, source_locale)
+        time.sleep(0.2)
+
+        results.append(
+            {
+                "key": key,
+                "original_english": original_en,
+                "translated": translated_text,
+                "back_translated": back_translated or "ERROR: request failed",
+            }
+        )
+
+    output = {"total": total, "locale": source_locale, "results": results}
+    print(json.dumps(output, indent=2, ensure_ascii=False))
+    print(f"\nDone: {total} entries back-translated.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ bin/
 .java-version
 *.iml
 .idea
+.vscode/
+.factorypath
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build Commands
 
+**Requires JDK 17+** (CI tests on JDK 17 and 21)
+
 ```bash
 mvn clean verify          # Full build + tests + SpotBugs + Spotless check
 mvn clean test            # Compile and run unit tests only
@@ -31,14 +33,26 @@ This is a Jenkins plugin (HPI packaging) that displays a Chuck Norris fact and i
 
 **Core flow:** Both paths create a `RoundhouseAction` attached to the build run. This action stores a random fact index and a `Style` (THUMB_UP/ALERT/BAD_ASS based on build result). Jelly templates (`summary.jelly`, `floatingBox.jelly`) render the image and fact on build/project pages.
 
+**Gotcha:** `RoundhouseAction` has legacy fields (`style`, `fact`) for backward compatibility with v0.2 serialized data — do not remove them even though they appear unused.
+
 **Localization:** `FactGenerator` uses Java `ResourceBundle` to load locale-specific facts from `FactGenerator[_locale].properties`. Facts are resolved at display time using the browser's locale via `StaplerRequest2.getLocale()`. Non-ASCII characters in properties files must use `\uXXXX` Unicode escapes.
 
 ## Adding a Translation
 
+Use the `/add-translation <language>` skill to automate this entire workflow, including back-translation verification and git workflow.
+
+**Manual steps:**
 1. Create `src/main/resources/hudson/plugins/chucknorris/FactGenerator_XX.properties` (XX = locale code)
 2. Include `fact.count=82` and keys `fact.0` through `fact.81` with Unicode-escaped diacritics
-3. Add a test in `FactGeneratorTest` verifying the new locale differs from English
-4. Update the Localization section in `README.md`
+3. Verify translation quality via Google Translate back-translation (use `.claude/skills/add-translation/scripts/back_translate.py`) — Claude's own back-translation has blind spots since the same model can make consistent errors in both directions
+4. Add a test in `FactGeneratorTest` verifying the new locale differs from English
+5. Update the Localization section in `README.md`
+
+## Git Conventions
+
+- Commit messages must include a title AND a descriptive body (not just a title)
+- Translation branches: `feature/i18n-facts-XX` (XX = locale code)
+- Always run `mvn clean spotless:apply` and `mvn clean verify` before pushing
 
 ## CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+mvn clean verify          # Full build + tests + SpotBugs + Spotless check
+mvn clean test            # Compile and run unit tests only
+mvn test -Dtest=FactGeneratorTest                 # Run a single test class
+mvn test -Dtest=FactGeneratorTest#testGetFactReturnsItalian  # Run a single test method
+mvn spotless:apply        # Auto-fix code formatting
+mvn spotless:check        # Check formatting without fixing
+mvn clean hpi:hpi         # Build the .hpi plugin package
+```
+
+## Code Quality
+
+- **Spotless** enforces formatting (`spotless.check.skip=false`) -- run `mvn spotless:apply` before committing
+- **SpotBugs** runs at max effort/low threshold during `verify`
+- **JUnit 4 imports are banned** -- use JUnit 5 (Jupiter) exclusively
+- Tests use `@WithJenkins` + `JenkinsRule` for integration tests needing a Jenkins instance
+
+## Architecture
+
+This is a Jenkins plugin (HPI packaging) that displays a Chuck Norris fact and image on build/project pages.
+
+**Two entry points into Jenkins:**
+- **Freestyle/Maven jobs:** `CordellWalkerRecorder` (extends `Recorder`, implements `SimpleBuildStep`) -- configured as a post-build action via `BeardDescriptor`
+- **Pipeline jobs:** `ChuckNorrisStep` -- invoked as `chuckNorris()` in Jenkinsfiles, delegates to `ChuckNorrisStepExecution` which creates a `CordellWalkerRecorder`
+
+**Core flow:** Both paths create a `RoundhouseAction` attached to the build run. This action stores a random fact index and a `Style` (THUMB_UP/ALERT/BAD_ASS based on build result). Jelly templates (`summary.jelly`, `floatingBox.jelly`) render the image and fact on build/project pages.
+
+**Localization:** `FactGenerator` uses Java `ResourceBundle` to load locale-specific facts from `FactGenerator[_locale].properties`. Facts are resolved at display time using the browser's locale via `StaplerRequest2.getLocale()`. Non-ASCII characters in properties files must use `\uXXXX` Unicode escapes.
+
+## Adding a Translation
+
+1. Create `src/main/resources/hudson/plugins/chucknorris/FactGenerator_XX.properties` (XX = locale code)
+2. Include `fact.count=82` and keys `fact.0` through `fact.81` with Unicode-escaped diacritics
+3. Add a test in `FactGeneratorTest` verifying the new locale differs from English
+4. Update the Localization section in `README.md`
+
+## CI
+
+- **Jenkinsfile:** `buildPlugin()` on Linux (JDK 21) and Windows (JDK 17)
+- **GitHub Actions:** `cd.yaml` for continuous delivery, `jenkins-security-scan.yml` for security scanning
+- **Renovate** manages dependency updates via `jenkinsci/renovate-config`


### PR DESCRIPTION
- Update CLAUDE.md with JDK version requirement, RoundhouseAction legacy fields gotcha, add-translation skill reference, back-translation verification step, and git conventions section
- Add .claude/ directory with project plugin settings (`jdtls-lsp`,`skill-creator`, `code-simplifier`, `claude-md-management`, `hookify`) and the `add-translation` skill with back-translation verification script
- Update `.gitignore` to exclude `.vscode/`, `.factorypath`, and `.claude/settings.local.json`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Testing done

- none; just documentation
- will fully test the `/add-translation` skill on next language PR

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed